### PR TITLE
This removes even dummy annotations from the code.

### DIFF
--- a/Physiolibrary/Blocks.mo
+++ b/Physiolibrary/Blocks.mo
@@ -89,11 +89,9 @@ This is discussed in the description of package
           parameter Real k(start=1) "value added to input signal";
     public
           Modelica.Blocks.Interfaces.RealInput u "Input signal connector"
-            annotation (Placement(transformation(extent={{-140,-20},{-100,20}},
-              rotation=0)));
+            annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
           Modelica.Blocks.Interfaces.RealOutput y "Output signal connector"
-            annotation (Placement(transformation(extent={{100,-10},{120,10}},
-              rotation=0)));
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 
         equation
           y = k+u;
@@ -144,10 +142,6 @@ This is discussed in the description of package
               extent={{-100,100},{100,-100}},
               lineColor={0,0,0},
               textString="1/u")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2}), graphics),
             Documentation(info="<html>
 <p>This blocks computes the output <b>y</b> as <i>reciprocal value</i> of the input <b>u</b>: </p>
 <p><code>    y = 1 / u ;</code> </p>
@@ -192,12 +186,7 @@ This is discussed in the description of package
               fillPattern=FillPattern.Solid), Text(
               extent={{-100,-40},{100,40}},
               lineColor={0,0,0},
-                  textString="b^u")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-                initialScale=0.04), graphics));
+                  textString="b^u")}));
         end Exponentiation;
 
     block Min "Pass through the smallest signal"
@@ -320,9 +309,9 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
 <p><code>    u = (w[1]*y[1] + w[2]*y[2] + ... + w[n]*y[n]) / (w[1] + w[2] + ... + w[n]);</code></p>
 <p>Example: </p>
 <pre>     parameter:   nin = 3;  w=ones(3);
- 
+
   results in the following equations:
- 
+
 <p><code>     y[1]=u/3,  y[2]=u/3,  y[3]=u/3;</code> </p>
 </html>"),  Icon(coordinateSystem(
             preserveAspectRatio=true,
@@ -330,11 +319,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
             grid={2,2}), graphics={Text(
               extent={{-100,-100},{100,100}},
               lineColor={0,0,0},
-              textString="Parts")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2}), graphics));
+              textString="Parts")}));
         end Parts;
 
         block HomotopyStrongComponentBreaker
@@ -507,8 +492,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
                 a,
                 u);
 
-           annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),      graphics), Icon(coordinateSystem(
+           annotation ( Icon(coordinateSystem(
               preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
             graphics={
             Rectangle(
@@ -548,15 +532,13 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
     equation
       effect = u/NormalValue;
       y=effect*yBase;
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>",
         info="<html>
 <p><h4>y = yBase * u</h4></p>
-</html>"),
-        Icon(graphics));
+</html>"));
     end Normalization;
 
     model DamagedFraction "effect = 1 - DamagedAreaFraction"
@@ -590,8 +572,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
       effect = Interpolation.Spline(
                              data[:, 1],a,u);
       y=effect*yBase;
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -658,8 +639,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
           points={{-26,1},{-26,-8},{-6,-8},{-6,-20}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -726,8 +706,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
           points={{-8,28},{-6,28},{-6,-20}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>", info="<html>
@@ -814,10 +793,7 @@ the Real inputs <b>u[1]</b>,<b>u[2]</b> .. <b>u[nin]</b>:
           points={{-38,50},{-78,50},{-78,40},{-100,40}},
           color={255,0,255},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),       graphics), Icon(coordinateSystem(
-              preserveAspectRatio=true,  extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+      annotation (        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));

--- a/Physiolibrary/Chemical.mo
+++ b/Physiolibrary/Chemical.mo
@@ -29,13 +29,11 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
           color={107,45,134},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=1e-007),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=1e-007));
     end SimpleReaction;
 
     model SimpleReaction2
@@ -68,13 +66,11 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
           color={107,45,134},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=1e-009),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=1e-009));
     end SimpleReaction2;
 
     model ExothermicReaction
@@ -118,13 +114,11 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
           color={191,0,0},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=5),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=5));
     end ExothermicReaction;
 
     model MichaelisMenten "Basic enzyme kinetics"
@@ -203,15 +197,11 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
           color={107,45,134},
           thickness=1,
           smooth=Smooth.None));
-          annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),     graphics),
-                  Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+          annotation ( Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=1),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=1));
     end MichaelisMenten;
 
     model HendersonHaselbalch
@@ -269,8 +259,7 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
           color={107,45,134},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(info="<html>
+      annotation ( Documentation(info="<html>
 <p>Henderson-Hasselbalch equation in ideal buffered solution, where pH remains constant.</p>
 <p>The partial pressure of CO2 in gas are input parameter. Outputs are an amount of free disolved CO2 in liquid and an amount of HCO3-.</p>
 </html>"));
@@ -762,11 +751,8 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
             points={{-73,54},{-66,54},{-66,34}},
             color={0,0,127},
             smooth=Smooth.None));
-        annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                  -100},{100,100}}), graphics),
-          experiment(StopTime=10000),
-          __Dymola_experimentSetupOutput,
-          Documentation(info="<html>
+        annotation (          experiment(StopTime=10000),
+Documentation(info="<html>
 <p>To understand the model is necessary to study the principles of MWC allosteric transitions first published by </p>
 <p>Monod,Wyman,Changeux (1965). &QUOT;On the nature of allosteric transitions: a plausible model.&QUOT; Journal of molecular biology 12(1): 88-118.</p>
 <p><br/>In short it is about binding oxygen to hemoglobin.</p>
@@ -871,7 +857,6 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
                0.026029047188736, T=310.15)                             annotation (Placement(
               transformation(
               extent={{-10,-10},{10,10}},
-              rotation=0,
               origin={6,32})));
         SteadyStates.Components.MolarConservationLaw totalHb(
           Simulation=Physiolibrary.Types.SimulationType.SteadyState,
@@ -1054,8 +1039,7 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
                 fillPattern=FillPattern.Solid,
                 pattern=LinePattern.None)}),
           experiment(StopTime=10000),
-          __Dymola_experimentSetupOutput,
-          Documentation(revisions="<html>
+Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>", info="<html>
@@ -1125,8 +1109,7 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
       change = q_out.q;
 
                                                                                                         annotation (choicesAllMatching=true,
-                  Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Icon(coordinateSystem(
+ Icon(coordinateSystem(
               preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
             graphics={                                    Text(
               extent={{-22,-102},{220,-136}},
@@ -1241,8 +1224,6 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
               smooth=Smooth.None,
               fillColor={0,0,0},
               fillPattern=FillPattern.Solid)}),
-                                      Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -1250,21 +1231,21 @@ package Chemical "Domain with Molar Concentration and Molar Flow"
 <pre>The Chemical reaction
 
 Schema of chemical reaction:
-s[1]*S[1] + .. + s[nS]*S[nS]  &LT;-&GT;  p[1]*P[1] + .. + p[nP]*P[nP] 
+s[1]*S[1] + .. + s[nS]*S[nS]  &LT;-&GT;  p[1]*P[1] + .. + p[nP]*P[nP]
 
 where
-S are substrates, 
-s are stochiometric coefficients of substrates,  
-P are products, 
-p are stochiometric coefficients of products.  
+S are substrates,
+s are stochiometric coefficients of substrates,
+P are products,
+p are stochiometric coefficients of products.
 
 In equilibrium (at zero reaction flow) it fullfil, the dissociation constant K equation:
 <p><br/><code>K = <font style=\"color: #ff0000; \">&nbsp;product</font>(P.^p) / <font style=\"color: #ff0000; \">product</font>(S.^s)</code></p>
-<pre> 
+<pre>
 The dissociation constant is dependent on temperature by Hoff&apos;s equation using reaction enthalphy change parameter dH.
 <p><br/><code>The forward rate is kf*volume*<font style=\"color: #ff0000; \">product</font>(S.^s), where kf is forward rate coefficient. </code></p>
 <p><code>The backward rate is (kf/K)*<font style=\"color: #ff0000; \">product</font>(P.^p), where backward rate coefficient kb is kf/K.</code></p>
-<pre> 
+<pre>
 
 It works in two modes:
 
@@ -1272,8 +1253,7 @@ It works in two modes:
 1. Dynamic mode, if EQUILIBRIUM=false.
 
 2. Equilibrium mode, if EQUILIBRIUM=true and all Substances are in STEADY mode. But some zero flows must be removed instead of additional steady-state equation. </pre>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end ChemicalReaction;
 
     model Diffusion "Solute diffusion"
@@ -1302,7 +1282,7 @@ It works in two modes:
 
        q_in.q = c * (q_in.conc - q_out.conc);
 
-       annotation (Icon(graphics),                 Documentation(revisions="<html>
+       annotation (                 Documentation(revisions="<html>
 <p><i>2009-2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>",     info="<html>
@@ -1314,9 +1294,7 @@ It works in two modes:
 <p>dPhi is concentration gradient [mol/m3].</p>
 <p>dx is length of diffusion [m].</p>
 <p><br/>So for example of the diffusion through membrane the parameter cond = <code>(D/membrameThicknes)*membraneArea.</code></p>
-</html>"),
-        Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-                100}}), graphics));
+</html>"));
     end Diffusion;
 
     model GasSolubility "Henry's law of gas solubility in liquid."
@@ -1446,8 +1424,6 @@ It works in two modes:
               smooth=Smooth.None,
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid)}),
-                                      Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <table>
 <tr>
@@ -1467,8 +1443,7 @@ It works in two modes:
 <td>2013</td>
 </tr>
 </table>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end Degradation;
 
     model Clearance "Clearance with or without solvent outflow"
@@ -1526,9 +1501,7 @@ It works in two modes:
             Text(
               extent={{-100,-30},{100,-50}},
               lineColor={0,0,0},
-              textString="K=%K")}),   Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              textString="K=%K")}),        Documentation(revisions="<html>
 <table>
 <tr>
 <td>Author:</td>
@@ -1547,8 +1520,7 @@ It works in two modes:
 <td>2009</td>
 </tr>
 </table>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end Clearance;
 
     model Stream "Flow of whole solution"
@@ -1567,14 +1539,12 @@ It works in two modes:
               lineColor={0,0,127},
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
-              origin={0,0},
               rotation=360),
             Polygon(
               points={{-80,25},{80,0},{-80,-25},{-80,25}},
               lineColor={0,0,127},
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
-              origin={0,0},
               rotation=360),
             Text(
               extent={{-150,-20},{150,20}},
@@ -1582,8 +1552,6 @@ It works in two modes:
               lineColor={0,0,255},
               origin={2,-74},
               rotation=180)}),
-         Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <table>
 <tr>
@@ -1646,27 +1614,22 @@ It works in two modes:
               lineColor={0,0,127},
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
-              origin={0,0},
               rotation=360),
             Polygon(
               points={{-80,25},{80,0},{-80,-25},{-80,25}},
               lineColor={0,0,127},
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid,
-              origin={0,0},
               rotation=360),
             Text(
               extent={{-150,-20},{150,20}},
               lineColor={0,0,255},
               origin={-10,-76},
               rotation=360,
-              textString="%name")}),  Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              textString="%name")}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end SolutePump;
 
     model Speciation
@@ -1770,8 +1733,6 @@ It works in two modes:
               lineColor={0,0,255},
               origin={0,-60},
               rotation=180)}),
-        Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -1855,9 +1816,7 @@ It works in two modes:
             Text(
               extent={{0,-102},{154,-132}},
               lineColor={0,0,255},
-              textString="%name")}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                      extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              textString="%name")}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -1883,9 +1842,6 @@ It works in two modes:
       actualFlow = q_in.q;
 
      annotation (
-        Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},{
-                100,100}}), graphics),Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -1916,8 +1872,6 @@ It works in two modes:
               lineColor={0,0,255},
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid)}),
-                                      Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -1967,13 +1921,10 @@ It works in two modes:
               fillPattern=FillPattern.Solid), Text(
               extent={{-88,-50},{80,50}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end FlowConcentrationMeasure;
   end Sensors;
 
@@ -2007,13 +1958,10 @@ It works in two modes:
             Text(
               extent={{-82,-82},{90,-58}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end UnlimitedSolutePump;
 
     model UnlimitedSolutionStorage "Constant concentration source"
@@ -2063,8 +2011,7 @@ It works in two modes:
         q_out.q = 0;
       end if;
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),       graphics), Icon(coordinateSystem(
+      annotation ( Icon(coordinateSystem(
               preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
             graphics={
             Rectangle(
@@ -2119,8 +2066,7 @@ It works in two modes:
 
       RealIO.PressureInput partialPressure(start=PartialPressure) = p if usePartialPressureInput
         "Partial pressure of Gas = air pressure * gas fraction"
-        annotation (Placement(transformation(extent={{-120,-20},{-80,20}},
-            rotation=0)));
+        annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
      parameter Boolean isIsolatedInSteadyState = true
         "=true, if there is no flow at port in steady state"
@@ -2151,8 +2097,7 @@ It works in two modes:
 
       lossHeat=0; //only read temperature from heat port
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),       graphics), Icon(coordinateSystem(
+      annotation ( Icon(coordinateSystem(
               preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
             graphics={
             Rectangle(
@@ -2285,10 +2230,6 @@ Connector with one flow signal of type Real.
         annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
     equation
       q_in.q + q_out.q = 0;
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),
-                             graphics), Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end OnePort;
 
     partial model ConditionalHeatPort
@@ -2312,18 +2253,14 @@ Connector with one flow signal of type Real.
          T_heatPort = T;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+      annotation (        Documentation(revisions="<html>
 <ul>
 <li><i> February 17, 2009   </i>
        by Christoph Clauss<br> initially implemented<br>
        </li>
 <li><i> January 21, 2014   </i>
        by Marek Matejak<br> integrated to Physiolibrary<br>
-       </li>  
+       </li>
 </ul>
 </html>",     info="<html>
 <p>
@@ -2365,10 +2302,6 @@ on the model behaviour.
         volume = NormalSolventVolume;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end ConditionalSolventVolume;
 
     partial model ConditionalSolutionFlow
@@ -2393,10 +2326,6 @@ on the model behaviour.
         q = SolutionFlow;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end ConditionalSolutionFlow;
 
     partial model ConditionalSoluteFlow
@@ -2421,10 +2350,6 @@ on the model behaviour.
         q = SoluteFlow;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end ConditionalSoluteFlow;
   end Interfaces;
   annotation (Documentation(revisions="<html>

--- a/Physiolibrary/Hydraulic.mo
+++ b/Physiolibrary/Hydraulic.mo
@@ -314,8 +314,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
 <p><i>2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=300),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=300));
     end CardiovascularSystem_GCG;
 
   end Examples;
@@ -357,8 +356,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
               fillColor={58,117,175},
               fillPattern=FillPattern.Solid,
               textString="%name")}),
-                                  Diagram(coordinateSystem(preserveAspectRatio=
-                false, extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -458,11 +455,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
                 100}}),     graphics={Text(
               extent={{-240,-150},{238,-110}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-                  Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -491,9 +484,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
             Text(
               extent={{-150,-90},{150,-50}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <table>
 <tr>
 <td>Author:</td>
@@ -541,7 +532,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
         "Vertical distance between top and bottom connector"
                                                    annotation (Placement(transformation(extent={{-20,-20},
                 {20,20}},
-            rotation=0,
             origin={-60,0})));
 
       parameter Modelica.SIunits.Density ro=1060; //liquid density
@@ -596,14 +586,10 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
       q_up.q + q_down.q = 0;
 
      annotation (
-        Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
-                            graphics),Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end HydrostaticColumn;
 
     model ElasticMembrane "Interaction between internal and external cavities"
@@ -638,11 +624,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
       change = q_int.q;
 
       // assert(volume>=-Modelica.Constants.eps,"Totally collapsed compartments are not supported!");
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}),
-            graphics),
-        Documentation(revisions="<html>
+      annotation (        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -664,15 +646,12 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
     equation
       state = q_in.q;      // I*der(q_in.q) = (q_in.pressure - q_out.pressure);
       change = (q_in.pressure - q_out.pressure)/I;
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),                Documentation(info="<html>
+      annotation (                Documentation(info="<html>
 <p>Inertance I of the simple tube could be calculated as I=ro*l/A, where ro is fuid density, l is tube length and A is tube cross-section area.</p>
 </html>", revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),
-        Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}), graphics));
+</html>"));
     end Inertia;
 
     model Reabsorption "Divide inflow to outflow and reabsorption"
@@ -724,9 +703,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
                 {100,100}}),       graphics={Text(
               extent={{-100,130},{100,108}},
               lineColor={0,0,255},
-              textString="%name")}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                      extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              textString="%name")}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>",     info="<html>
@@ -814,8 +791,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
               fillPattern=FillPattern.Sphere,
               fillColor={255,85,85},
               textString="%name")}),
-        Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-                100}}),      graphics),
         Documentation(info="<html>
 <p>Ideal Valve allows a volumetric flow in one direction in case of pressure gradient is greater. </p>
 </html>", revisions="<html>
@@ -844,9 +819,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
       actualFlow = q_in.q;
 
      annotation (
-        Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},{100,
-                100}}),     graphics),Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -867,9 +839,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
       actualPressure = q_in.pressure;
       q_in.q = 0;
      annotation (
-        Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},{100,
-                100}}),     graphics),Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -905,9 +874,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
             Text(
               extent={{-150,-94},{150,-54}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <table>
 <tr>
 <td>Author:</td>
@@ -942,13 +909,11 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
           annotation (Dialog(enable=not usePressureInput));
 
         RealIO.PressureInput pressure(start=P)=p if usePressureInput "Pressure"
-          annotation (Placement(transformation(extent={{-120,-20},{-80,20}},
-              rotation=0)));
+          annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
         Interfaces.HydraulicPort_a
                              y "PressureFlow output connectors"
-          annotation (Placement(transformation(extent={{84,-16},{116,16}},
-              rotation=0)));
+          annotation (Placement(transformation(extent={{84,-16},{116,16}})));
 
        parameter Boolean isIsolatedInSteadyState = true
         "=true, if there is no flow at port in steady state"
@@ -1009,9 +974,7 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
               Text(
                 extent={{-150,150},{150,110}},
                 textString="%name",
-                lineColor={0,0,255})}),
-          Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-                  100}}), graphics));
+                lineColor={0,0,255})}));
       end UnlimitedVolume;
   end Sources;
 
@@ -1062,7 +1025,6 @@ package Hydraulic "Domain with Pressure and Volumetric Flow"
               smooth=Smooth.None,
               fillPattern=FillPattern.Solid,
               fillColor={0,0,0},
-              origin={0,0},
               rotation=180)}),
         Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{
                 100,100}}), graphics={Polygon(
@@ -1122,9 +1084,6 @@ Connector with one flow signal of type Real.
 
       volumeFlowRate = q_in.q;
       dp = q_in.pressure - q_out.pressure;
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}), graphics), Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end OnePort;
   end Interfaces;
   annotation (Documentation(revisions="<html>

--- a/Physiolibrary/Icons.mo
+++ b/Physiolibrary/Icons.mo
@@ -4,8 +4,6 @@ package Icons "Icons for physiological models"
   extends Modelica.Icons.Package;
   package Library
       extends Modelica.Icons.Package;
-    annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-              -100},{100,100}}), graphics));
   end Library;
 
   model Golem
@@ -391,8 +389,6 @@ package Icons "Icons for physiological models"
 
   package BaseLib
     extends Modelica.Icons.Package;
-    annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-              -100},{100,100}}), graphics));
   end BaseLib;
 
   package HormonesLib
@@ -547,8 +543,7 @@ package Icons "Icons for physiological models"
 
   model MetabolismPart
 
-    annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},
-              {100,120}}),            graphics), Icon(coordinateSystem(
+    annotation ( Icon(coordinateSystem(
             preserveAspectRatio=true, extent={{-100,-100},{100,120}}),
           graphics={             Bitmap(extent={{28,120},{98,44}}, fileName=
                "modelica://Physiolibrary/Resources/Icons/ohen.png")}));
@@ -819,9 +814,7 @@ package Icons "Icons for physiological models"
             fillPattern=FillPattern.Sphere), Text(
             extent={{-90,-10},{92,10}},
             textString="%name",
-            lineColor={0,0,0})}), Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+            lineColor={0,0,0})}));
   end BaseFactorIcon;
 
   partial model BaseFactorIcon2
@@ -849,9 +842,7 @@ package Icons "Icons for physiological models"
             extent={{-86,-36},{100,40}},
             textString="%name",
             lineColor={0,0,0},
-            fillPattern=FillPattern.Sphere)}), Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+            fillPattern=FillPattern.Sphere)}));
   end BaseFactorIcon2;
 
   partial model BaseFactorIcon3
@@ -878,9 +869,7 @@ package Icons "Icons for physiological models"
             fillPattern=FillPattern.Sphere), Text(
             extent={{-90,-10},{92,10}},
             textString="%name",
-            lineColor={0,0,0})}), Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+            lineColor={0,0,0})}));
   end BaseFactorIcon3;
 
   partial model BaseFactorIcon4
@@ -907,9 +896,7 @@ package Icons "Icons for physiological models"
             fillPattern=FillPattern.Sphere), Text(
             extent={{-90,-10},{92,10}},
             textString="%name",
-            lineColor={0,0,0})}), Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+            lineColor={0,0,0})}));
   end BaseFactorIcon4;
 
   partial model BaseFactorIcon5
@@ -936,9 +923,7 @@ package Icons "Icons for physiological models"
             fillPattern=FillPattern.Sphere), Text(
             extent={{-90,-10},{92,10}},
             textString="%name",
-            lineColor={0,0,0})}), Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+            lineColor={0,0,0})}));
   end BaseFactorIcon5;
 
   partial model BaseFactorIcon6
@@ -962,10 +947,7 @@ package Icons "Icons for physiological models"
           extent={{-100,20},{100,-20}},
           lineColor={0,87,87},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Sphere)}),
-                                  Diagram(coordinateSystem(
-            preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
-          graphics));
+          fillPattern=FillPattern.Sphere)}));
   end BaseFactorIcon6;
 
   partial class ConversionIcon "Base icon for conversion functions"
@@ -995,8 +977,7 @@ package Icons "Icons for physiological models"
 
   model Substance
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-              -100},{100,100}}), graphics), Icon(coordinateSystem(
+      annotation ( Icon(coordinateSystem(
             preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
           graphics={Bitmap(extent={{-100,100},{100,-100}}, fileName=
                 "modelica://Physiolibrary/Resources/Icons/Concentration.png"), Text(
@@ -1007,8 +988,7 @@ package Icons "Icons for physiological models"
 
   model Speciation
 
-    annotation (Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-              -100},{100,100}}), graphics), Icon(coordinateSystem(
+    annotation ( Icon(coordinateSystem(
             preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
           graphics={Bitmap(extent={{-100,100},{100,-100}}, fileName=
                 "modelica://Physiolibrary/Resources/Icons/Speciation.png"), Text(
@@ -1101,8 +1081,7 @@ package Icons "Icons for physiological models"
 
   model PressureMeasure
 
-    annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{
-              -100,-100},{100,100}}), graphics), Icon(graphics={Bitmap(extent={
+    annotation ( Icon(graphics={Bitmap(extent={
                 {-100,100},{100,-100}}, fileName=
                 "modelica://Physiolibrary/Resources/Icons/pressureMeassure.png")}));
   end PressureMeasure;

--- a/Physiolibrary/Osmotic.mo
+++ b/Physiolibrary/Osmotic.mo
@@ -67,8 +67,7 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
               smooth=Smooth.None,
               thickness=1)}),
         experiment(StopTime=60),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -281,8 +280,7 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
               smooth=Smooth.None,
               arrow={Arrow.None,Arrow.Filled})}),
         experiment(StopTime=86400),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>", info="<html>
@@ -343,8 +341,7 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
 
       //  assert(volume>=-Modelica.Constants.eps,"Collapsed cells by osmotic pressure are not supported!");
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
-                -100},{100,100}}), graphics), Icon(coordinateSystem(
+      annotation ( Icon(coordinateSystem(
               preserveAspectRatio=false,extent={{-100,-100},{100,100}}),
                                                    graphics={
                                    Text(
@@ -416,12 +413,7 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
       end if;
 
       q_in.q = cond * ( (-po + q_out.o*(Modelica.Constants.R*to)) - (-pi + q_in.o*(Modelica.Constants.R*ti)));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),
-                          graphics), Icon(coordinateSystem(preserveAspectRatio=false,
-              extent={{-100,-100},{100,100}}),
-                                          graphics),
-        Documentation(revisions="<html>
+      annotation (        Documentation(revisions="<html>
 <p><i>2009-2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -451,13 +443,10 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
               lineColor={0,0,127},
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid)}),
-                                      Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end SolventFlux;
   end Components;
 
@@ -478,9 +467,6 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
       actualFlow = q_in.q;
 
      annotation (
-        Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,-100},{100,100}}),
-                            graphics),Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
         Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
@@ -517,13 +503,10 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
             Text(
               extent={{-92,-58},{80,-34}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end SolventInflux;
 
     model SolventOutflux "Prescribed solvent outflow"
@@ -551,13 +534,10 @@ package Osmotic "Domain with Osmorarity and Solvent Volumetric Flow"
             Text(
               extent={{-78,-58},{72,-36}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end SolventOutflux;
 
     model UnlimitedSolution "Prescribed osmolarity"
@@ -641,8 +621,7 @@ This model defines a fixed temperature T at its port in Kelvin,
 i.e., it defines a fixed temperature as a boundary condition.
 </p>
 </HTML>
-"),     Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},{100,
-                100}}),     graphics));
+"));
     end UnlimitedSolution;
   end Sources;
 
@@ -737,7 +716,7 @@ Connector with one flow signal of type Real.
             transformation(extent={{90,-10},{110,10}})));
     equation
       q_in.q + q_out.q = 0;
-      annotation (Icon(graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -765,10 +744,6 @@ Connector with one flow signal of type Real.
         q = SolventFlow;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end ConditionalSolventFlow;
   end Interfaces;
   annotation (Documentation(revisions="<html>

--- a/Physiolibrary/Resources/DisplayUnits/displayunit.mos
+++ b/Physiolibrary/Resources/DisplayUnits/displayunit.mos
@@ -42,12 +42,12 @@ defineUnitConversion("m3/s", "ml/min", (10^6)*60 ); //diffusion permeability
 defineUnitConversion("m3/s", "(mmol/min)/(mmol/l)", (10^3)*60 ); //diffusion permeability
 
 //gas solubility - Henry's constant
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/(mmol/l)", 1 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "%", 100 ); 
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/(mmol/l)", 1 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "%", 100 );
 
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/Pa at 0 degC", 4.40316172572e-4 ); // 1/(R*T)=1/(8.3144621*273.15)
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/Pa at 20degC", 4.10275840143e-4 ); // 1/(R*T)=1/(8.3144621*293.15)
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/Pa at 25degC", 4.03395480590e-4 ); // 1/(R*T)=1/(8.3144621*298.15) 
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/Pa at 25degC", 4.03395480590e-4 ); // 1/(R*T)=1/(8.3144621*298.15)
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/Pa at 37degC", 3.87787723805e-4 ); // 1/(R*T)=1/(8.3144621*310.15)
 
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/Pa at 0 degC",  4.40316172572e-7 );  //STP:   0degC
@@ -55,30 +55,30 @@ defineUnitConversion("(mol/m3)/(mol/m3)", "%", 100 );
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/Pa at 25degC",  4.03395480590e-7 );  //SATP: 25degC
 //defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/Pa at 37degC",  3.87787723805e-7 );  //SBTP = standard body temperature: 37degC
 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 0 degC", 4.40316172572e-4 ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 20degC", 4.10275840143e-4  ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 25degC", 4.03395480590e-4  ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 37degC", 3.87787723805e-4  ); 
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 0 degC", 4.40316172572e-4 );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 20degC", 4.10275840143e-4  );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 25degC", 4.03395480590e-4  );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/kPa at 37degC", 3.87787723805e-4  );
 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 0 degC",  4.40316172572e-1 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 20degC",  4.10275840143e-1 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 25degC",  4.03395480590e-1 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 37degC",  3.87787723805e-1 ); 
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 0 degC",  4.40316172572e-1 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 20degC",  4.10275840143e-1 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 25degC",  4.03395480590e-1 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/kPa at 37degC",  3.87787723805e-1 );
 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 0 degC", (4.40316172572e-7)*133.322387415 ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 20degC", (4.10275840143e-7)*133.322387415 ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 25degC", (4.03395480590e-7)*133.322387415 ); 
-//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 37degC", (3.87787723805e-7)*133.322387415 ); 
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 0 degC", (4.40316172572e-7)*133.322387415 );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 20degC", (4.10275840143e-7)*133.322387415 );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 25degC", (4.03395480590e-7)*133.322387415 );
+//defineUnitConversion("(mol/m3)/(mol/m3)", "(mol/l)/mmHg at 37degC", (3.87787723805e-7)*133.322387415 );
 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 0 degC",  (4.40316172572e-4)*133.322387415 ); 
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 0 degC",  (4.40316172572e-4)*133.322387415 );
 defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 20degC",  (4.10275840143e-4)*133.322387415 );
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 25degC",  (4.03395480590e-4)*133.322387415 ); 
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 25degC",  (4.03395480590e-4)*133.322387415 );
 defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/mmHg at 37degC",  (3.87787723805e-4)*133.322387415 );
 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 0 degC", (4.40316172572e-1)*101.325 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 20degC", (4.10275840143e-1)*101.325 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 25degC", (4.03395480590e-1)*101.325 ); 
-defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 37degC", (3.87787723805e-1)*101.325 ); 
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 0 degC", (4.40316172572e-1)*101.325 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 20degC", (4.10275840143e-1)*101.325 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 25degC", (4.03395480590e-1)*101.325 );
+defineUnitConversion("(mol/m3)/(mol/m3)", "(mmol/l)/atm at 37degC", (3.87787723805e-1)*101.325 );
 
 
 //Osmolarity

--- a/Physiolibrary/Resources/Install/Dymola/install.bat
+++ b/Physiolibrary/Resources/Install/Dymola/install.bat
@@ -13,11 +13,11 @@ echo %PHYSIOLIBRARY%
 
 for /F delims^=^"^ tokens^=2 %%s in ('ftype mofile') DO set x=%%s
 call set DYMOLADIR=%%x:\bin%x:*\bin=%=%%
-set x= 
+set x=
 
 echo Selected Dymola directory is "%DYMOLADIR%".
 
-if "%1" == "EVEL" goto gotPrivileges  
+if "%1" == "EVEL" goto gotPrivileges
 
 
 
@@ -27,13 +27,13 @@ if NOT EXIST "%CurrentDirectory%\backup" mkdir "%CurrentDirectory%\backup"
 set DISPLAYUNIT_BACKUP_FILE=%CurrentDirectory%\backup\displayunit.mos-install_%date%_%time::=-%.bak
 copy "%DYMOLADIR%\insert\displayunit.mos" "%DISPLAYUNIT_BACKUP_FILE%"
 
-set UNINST=%CurrentDirectory%\uninstall.bat 
+set UNINST=%CurrentDirectory%\uninstall.bat
 
 echo NET FILE 1^>NUL 2^>NUL > "%UNINST%"
 echo if '%%errorlevel%%' == '0'  goto gotPrivileges >> "%UNINST%"
 echo ECHO Set UAC = CreateObject^^^("Shell.Application"^^^) ^> "%%temp%%\OEgetPrivileges.vbs"  >> "%UNINST%"
 echo ECHO UAC.ShellExecute "%PHYSIOLIBRARYDIR%\Resources\Install\Dymola\uninstall.bat", "EVEL", "", "runas", 1 ^>^> "%%temp%%\OEgetPrivileges.vbs" >> "%UNINST%"
-echo "%%temp%%\OEgetPrivileges.vbs" >> "%UNINST%" 
+echo "%%temp%%\OEgetPrivileges.vbs" >> "%UNINST%"
 echo exit /B >> "%UNINST%"
 echo :gotPrivileges >> "%UNINST%"
 echo copy "%DYMOLADIR%\insert\displayunit.mos" "%CurrentDirectory%\backup\displayunit.mos-uninstall_%%date%%_%%time::=-%%.bak" >>  "%UNINST%"
@@ -45,25 +45,25 @@ if "%PHYSIOLIBRARY%" NEQ "" echo rmdir /S /Q "%DYMOLADIR%\Modelica\Library\%PHYS
 rem ****** Check administration privileges *****
 
 NET FILE 1>NUL 2>NUL
-if '%errorlevel%' == '0' ( goto gotPrivileges ) else ( goto getPrivileges ) 
+if '%errorlevel%' == '0' ( goto gotPrivileges ) else ( goto getPrivileges )
 
 
 
 
 rem ****** Get administration privileges *****
-:getPrivileges 
+:getPrivileges
 
-ECHO Set UAC = CreateObject^("Shell.Application"^) > "%temp%\OEgetPrivileges.vbs" 
-ECHO UAC.ShellExecute "%PHYSIOLIBRARYDIR%\Resources\Install\Dymola\install.bat", "EVEL", "", "runas", 1 >> "%temp%\OEgetPrivileges.vbs" 
-"%temp%\OEgetPrivileges.vbs" 
+ECHO Set UAC = CreateObject^("Shell.Application"^) > "%temp%\OEgetPrivileges.vbs"
+ECHO UAC.ShellExecute "%PHYSIOLIBRARYDIR%\Resources\Install\Dymola\install.bat", "EVEL", "", "runas", 1 >> "%temp%\OEgetPrivileges.vbs"
+"%temp%\OEgetPrivileges.vbs"
 
 cd "%CurrentDirectory%"
 set CurrentDirectory=
-exit /B 
+exit /B
 
 
 rem ****** Copy files into ProgramFiles\Dymola directory *****
-:gotPrivileges 
+:gotPrivileges
 
 xcopy /Y "Resources\DisplayUnits\displayunit.mos" "%DYMOLADIR%\insert\"
 mkdir "%DYMOLADIR%\Modelica\Library\%PHYSIOLIBRARY%"

--- a/Physiolibrary/Resources/Install/JModelica/runExamples.bat
+++ b/Physiolibrary/Resources/Install/JModelica/runExamples.bat
@@ -1,5 +1,5 @@
 set MODELICAPATH=
-call c:\JModelica.org-1.13b1\IPython.bat Physiolibrary.Chemical.Examples.py 
+call c:\JModelica.org-1.13b1\IPython.bat Physiolibrary.Chemical.Examples.py
 call c:\JModelica.org-1.13b1\IPython.bat Physiolibrary.Hydraulic.Examples.py
 call c:\JModelica.org-1.13b1\IPython.bat Physiolibrary.Thermal.Examples.py
 call c:\JModelica.org-1.13b1\IPython.bat Physiolibrary.Osmotic.Examples.py

--- a/Physiolibrary/Resources/Install/OpenModelica/README.txt
+++ b/Physiolibrary/Resources/Install/OpenModelica/README.txt
@@ -1,3 +1,3 @@
 Download and install - https://openmodelica.org/
 
-Physiolibrary should be already included - menu: "File > System Libraries". 
+Physiolibrary should be already included - menu: "File > System Libraries".

--- a/Physiolibrary/Resources/Scripts/Dymola/ConvertPhysiolibrary_from_0.4934_to_1.2.mos
+++ b/Physiolibrary/Resources/Scripts/Dymola/ConvertPhysiolibrary_from_0.4934_to_1.2.mos
@@ -178,7 +178,7 @@ convertModifiers("Physiolibrary.Blocks.SoluteMassConstant",{"k"}  , {"k=%k%*0.00
 convertClass("Physiolibrary.Blocks.FlowConstant_mmol_per_hour","Physiolibrary.Types.Constants.MolarFlowRateConst");
 convertModifiers("Physiolibrary.Blocks.FlowConstant_mmol_per_hour",{"k"}  , {"k=%k%*2.777777777778e-7"}, true); //mmol/h
 convertClass("Physiolibrary.Blocks.HormoneFlowConstant_mmol","Physiolibrary.Types.Constants.MolarFlowRateConst");
-convertModifiers("Physiolibrary.Blocks.HormoneFlowConstant_mmol",{"k"}  , {"k=%k%*1.6666666666667e-05"}, true); //mmol/min 
+convertModifiers("Physiolibrary.Blocks.HormoneFlowConstant_mmol",{"k"}  , {"k=%k%*1.6666666666667e-05"}, true); //mmol/min
 convertClass("Physiolibrary.Blocks.HormoneFlowConstant_nmol","Physiolibrary.Types.Constants.MolarFlowRateConst");
 convertModifiers("Physiolibrary.Blocks.HormoneFlowConstant_nmol",{"k"}  , {"k=%k%*1.6666666666667e-11"}, true); //nmol/min
 convertClass("Physiolibrary.Blocks.HormoneFlowConstant_pmol","Physiolibrary.Types.Constants.MolarFlowRateConst");

--- a/Physiolibrary/Resources/Scripts/Dymola/ConvertPhysiolibrary_from_0.4980_to_2.1.mos
+++ b/Physiolibrary/Resources/Scripts/Dymola/ConvertPhysiolibrary_from_0.4980_to_2.1.mos
@@ -269,7 +269,7 @@ convertClass("Physiolibrary.Blocks.Sources.MolarFlowConstant","Physiolibrary.Typ
 convertClass("Physiolibrary.Blocks.Sources.FlowConstant_mmol_per_hour","Physiolibrary.Types.Constants.MolarFlowRateConst");
 convertModifiers("Physiolibrary.Blocks.Sources.FlowConstant_mmol_per_hour",{"k"}  , {"k=%k%*2.777777777778e-7"}, true); //mmol/h
 convertClass("Physiolibrary.Blocks.Sources.HormoneFlowConstant_mmol","Physiolibrary.Types.Constants.MolarFlowRateConst");
-convertModifiers("Physiolibrary.Blocks.Sources.HormoneFlowConstant_mmol",{"k"}  , {"k=%k%*1.6666666666667e-05"}, true); //mmol/min 
+convertModifiers("Physiolibrary.Blocks.Sources.HormoneFlowConstant_mmol",{"k"}  , {"k=%k%*1.6666666666667e-05"}, true); //mmol/min
 convertClass("Physiolibrary.Blocks.Sources.HormoneFlowConstant_nmol","Physiolibrary.Types.Constants.MolarFlowRateConst");
 convertModifiers("Physiolibrary.Blocks.Sources.HormoneFlowConstant_nmol",{"k"}  , {"k=%k%*1.6666666666667e-11"}, true); //nmol/min
 convertClass("Physiolibrary.Blocks.Sources.HormoneFlowConstant_pmol","Physiolibrary.Types.Constants.MolarFlowRateConst");

--- a/Physiolibrary/SteadyStates.mo
+++ b/Physiolibrary/SteadyStates.mo
@@ -51,9 +51,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-     experiment(StopTime=1),
-     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}), graphics));
+     experiment(StopTime=1));
     end SimpleReaction_in_Equilibrium;
 
     model SimpleReaction_NormalInit
@@ -103,10 +101,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-     experiment(StopTime=1e-008),
-     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-                100,100}}),  graphics),
-        __Dymola_experimentSetupOutput);
+     experiment(StopTime=1e-008));
     end SimpleReaction_NormalInit;
 
     model SimpleReaction_InitSteadyState
@@ -156,10 +151,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-     experiment(StopTime=1e-008),
-     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-                100,100}}),  graphics),
-        __Dymola_experimentSetupOutput);
+     experiment(StopTime=1e-008));
     end SimpleReaction_InitSteadyState;
 
     model SimpleReaction2_in_Equilibrium
@@ -231,9 +223,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
       annotation (Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"), experiment(StopTime=1),
-           Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"), experiment(StopTime=1));
     end SimpleReaction2_in_Equilibrium;
 
     model O2_in_water
@@ -296,11 +286,8 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{-36,-18},{-30,-18},{-30,70}},
           color={191,0,0},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),
-        experiment(StopTime=100),
-        __Dymola_experimentSetupOutput,
-        Documentation(info="<html>
+      annotation (        experiment(StopTime=100),
+Documentation(info="<html>
 <p>Partial pressure of oxygen in air is the air pressure multiplied by the fraction of the oxygen in air. Oxygen solubility</p>
 </html>", revisions="<html>
 <p><i>2013</i></p>
@@ -809,11 +796,8 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{44,-92},{44,-98},{64,-98},{64,-64.1},{71,-64.1}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),
-        experiment(StopTime=10000),
-        __Dymola_experimentSetupOutput,
-        Documentation(info="<html>
+      annotation (        experiment(StopTime=10000),
+Documentation(info="<html>
 <p>To understand the model is necessary to study the principles of MWC allosteric transitions first published by </p>
 <p>Monod,Wyman,Changeux (1965). &QUOT;On the nature of allosteric transitions: a plausible model.&QUOT; Journal of molecular biology 12(1): 88-118.</p>
 <p><br/>In short it is about binding oxygen to hemoglobin.</p>
@@ -909,7 +893,6 @@ package SteadyStates "Dynamic Simulation / Steady State"
         usePartialPressureInput=true,
         T=295.15)   annotation (Placement(transformation(
             extent={{-10,-10},{10,10}},
-            rotation=0,
             origin={-58,84})));
       Chemical.Components.GasSolubility gasSolubility(
                                           useHeatPort=false, kH_T0=
@@ -1054,11 +1037,8 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{52,-16.4},{52,-20},{38,-20},{38,-92.5},{71,-92.5}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),
-        experiment(StopTime=10000),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+      annotation (        experiment(StopTime=10000),
+Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -1104,9 +1084,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{24,-46},{24,-68},{52,-68},{52,-8},{68,-8}},
           color={0,0,127},
           smooth=Smooth.None));
-       annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),
-     experiment(StopTime=1),
+       annotation (     experiment(StopTime=1),
      Documentation(info="<html>
 <p>Cardiovascular subsystem in famous Guyton-Coleman-Granger model from 1972. </p>
 <p><br/>Model, all parameters and all initial values are from article: </p>
@@ -1154,9 +1132,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{50,-52},{52,-52},{52,-82.5},{70,-82.5}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (experiment(StopTime=1),
-     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics));
+      annotation (experiment(StopTime=1));
     end ThermalBody_QHP_STeadyState;
 
     model Cells_SteadyState
@@ -1199,9 +1175,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
           points={{44,-64},{44,-85},{70,-85}},
           color={0,0,127},
           smooth=Smooth.None));
-      annotation (experiment(StopTime=1),
-     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics));
+      annotation (experiment(StopTime=1));
     end Cells_SteadyState;
   end Examples;
 
@@ -1255,8 +1229,6 @@ package SteadyStates "Dynamic Simulation / Steady State"
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid,
               textString="Total(%Total)")}),
-                                     Diagram(coordinateSystem(preserveAspectRatio=false,
-              extent={{-100,-100},{100,100}}), graphics),
         Documentation(info="<html>
 </html>"));
     end EnergyConservationLaw;
@@ -1308,8 +1280,6 @@ package SteadyStates "Dynamic Simulation / Steady State"
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid,
               textString="Total(%Total)")}),
-                                     Diagram(coordinateSystem(preserveAspectRatio=false,
-              extent={{-100,-100},{100,100}}), graphics),
         Documentation(info="<html>
 </html>"));
     end MassConservationLaw;
@@ -1365,8 +1335,6 @@ package SteadyStates "Dynamic Simulation / Steady State"
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid,
               textString="Total(%Total)")}),
-                                     Diagram(coordinateSystem(preserveAspectRatio=false,
-              extent={{-100,-100},{100,100}}), graphics),
         Documentation(info="<html>
 </html>"));
     end MolarConservationLaw;
@@ -1419,8 +1387,6 @@ package SteadyStates "Dynamic Simulation / Steady State"
               fillColor={0,0,127},
               fillPattern=FillPattern.Solid,
               textString="Total(%Total)")}),
-                                     Diagram(coordinateSystem(preserveAspectRatio=false,
-              extent={{-100,-100},{100,100}}), graphics),
         Documentation(info="<html>
 </html>"));
     end ElectricChargeConservationLaw;
@@ -1507,8 +1473,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
          change = 0;
       end if;
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),Documentation(revisions="<html>
+      annotation (Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -1604,8 +1569,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
         end for;
       end if;
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics),Documentation(revisions="<html>
+      annotation (Documentation(revisions="<html>
 <p><i>2013</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -1648,8 +1612,7 @@ package SteadyStates "Dynamic Simulation / Steady State"
         //The difference from vector 'ones(NumberOfDependentStates)' could be used as the solver calculation error vector.
       end if;
 
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2013-2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));

--- a/Physiolibrary/Thermal.mo
+++ b/Physiolibrary/Thermal.mo
@@ -27,11 +27,8 @@ package Thermal
           color={191,0,0},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),      graphics),
-        experiment(StopTime=10000, Tolerance=1e-006),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+      annotation (        experiment(StopTime=10000, Tolerance=1e-006),
+Documentation(revisions="<html>
 <p><i>2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -73,11 +70,8 @@ package Thermal
           color={191,0,0},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),      graphics),
-        experiment(StopTime=10000, Tolerance=1e-006),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+      annotation (        experiment(StopTime=10000, Tolerance=1e-006),
+Documentation(revisions="<html>
 <p><i>2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -101,7 +95,6 @@ package Thermal
         useMassFlowInput=false,
         SpecificHeat=3851.856)      annotation (Placement(transformation(
             extent={{-10,-10},{10,10}},
-            rotation=0,
             origin={32,30})));
       Physiolibrary.Thermal.Components.HeatOutstream
                     urination
@@ -123,7 +116,6 @@ package Thermal
         useMassFlowInput=false,
         SpecificHeat=3851.856)    annotation (Placement(transformation(
             extent={{10,-10},{-10,10}},
-            rotation=0,
             origin={-28,2})));
       Physiolibrary.Thermal.Components.HeatOutstream
                     insensibleVapor(VaporizationHeat(displayUnit="kcal/g") = 2428344,
@@ -271,13 +263,11 @@ package Thermal
           color={191,0,0},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),      graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-        experiment(StopTime=3600),
-        __Dymola_experimentSetupOutput);
+        experiment(StopTime=3600));
     end ThermalBody_QHP;
 
     model SkinHeatTransferOnBloodFlow
@@ -302,11 +292,8 @@ package Thermal
           color={191,0,0},
           thickness=1,
           smooth=Smooth.None));
-      annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}),      graphics),
-        experiment(StopTime=10000, Tolerance=1e-006),
-        __Dymola_experimentSetupOutput,
-        Documentation(revisions="<html>
+      annotation (        experiment(StopTime=10000, Tolerance=1e-006),
+Documentation(revisions="<html>
 <p><i>2014</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"));
@@ -341,9 +328,7 @@ package Thermal
             Text(
               extent={{-144,-142},{156,-102}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>",     info="<html>
@@ -351,8 +336,7 @@ package Thermal
 <p><b>q_in.q=q_out.q is not the heat inflow to Radiator input</b>, but the heat convected from radiator to environment!</p>
 <p>The environment temperature is the same as radiator output temperature q_out.T. </p>
 <p>And the flow of heat from radiator to environment is driven by Fick principle.</p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end IdealRadiator;
 
     model HeatAccumulation "Accumulating of heat to substance"
@@ -408,8 +392,6 @@ package Thermal
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>"),
-         Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}),       graphics),
         Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
                 100}}),
              graphics={
@@ -451,9 +433,7 @@ package Thermal
               lineColor={0,0,255})}), Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),
-        Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}), graphics));
+</html>"));
     end Conductor;
 
     model Stream "Flow of whole heated mass"
@@ -482,9 +462,7 @@ package Thermal
             Text(
               extent={{20,-84},{320,-44}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
 </html>", info="<html>
@@ -512,8 +490,7 @@ package Thermal
 </tr>
 </table>
 <br/>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end Stream;
 
     model HeatOutstream
@@ -548,13 +525,10 @@ package Thermal
             Text(
               extent={{20,-84},{320,-44}},
               textString="%name",
-              lineColor={0,0,255})}), Diagram(coordinateSystem(preserveAspectRatio=false,
-                       extent={{-100,-100},{100,100}}), graphics),
-        Documentation(revisions="<html>
+              lineColor={0,0,255})}),        Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),        Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-                -100},{100,100}}), graphics));
+</html>"));
     end HeatOutstream;
 
   end Components;
@@ -645,9 +619,7 @@ i.e., it defines a fixed temperature as a boundary condition.
 ", revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),
-        Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),graphics));
+</html>"));
     end UnlimitedHeat;
   end Sources;
 
@@ -710,12 +682,10 @@ i.e., it defines a fixed temperature as a boundary condition.
             transformation(extent={{90,-10},{110,10}})));
     equation
       q_in.Q_flow + q_out.Q_flow = 0;
-      annotation (Icon(graphics), Documentation(revisions="<html>
+      annotation ( Documentation(revisions="<html>
 <p><i>2009-2010</i></p>
 <p>Marek Matejak, Charles University, Prague, Czech Republic </p>
-</html>"),
-        Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
-                {100,100}}), graphics));
+</html>"));
     end OnePort;
 
     partial model ConditionalMassFlow
@@ -740,10 +710,6 @@ i.e., it defines a fixed temperature as a boundary condition.
         q = MassFlow;
       end if;
 
-      annotation (Icon(coordinateSystem(preserveAspectRatio=false,extent={{-100,-100},
-                {100,100}}),                                                                       graphics),
-                 Diagram(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
     end ConditionalMassFlow;
   end Interfaces;
   annotation (Documentation(revisions="<html>

--- a/Physiolibrary/Types.mo
+++ b/Physiolibrary/Types.mo
@@ -142,10 +142,7 @@ package Types "Physiological units with nominals"
           string="%second",
           index=1,
           extent={{6,3},{6,3}}));
-      annotation (experiment(StopTime=1),
-      Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
-                -100},{100,100}}), graphics), Icon(coordinateSystem(
-              preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics));
+      annotation (experiment(StopTime=1));
     end ParameterSet;
 
     model InputParameterSet
@@ -636,8 +633,7 @@ package Types "Physiological units with nominals"
   equation
         y=k;
     annotation (defaultComponentName="hydraulicElastance",
-               Diagram(coordinateSystem(extent={{-40,-40},{40,40}},
-            preserveAspectRatio=false), graphics),                    Icon(
+                    Icon(
           coordinateSystem(extent={{-40,-40},{40,40}}, preserveAspectRatio=false),
               graphics={
           Rectangle(extent={{-40,40},{40,-40}},
@@ -733,8 +729,7 @@ package Types "Physiological units with nominals"
   equation
         y=k;
     annotation (defaultComponentName="hydraulicResistance",
-               Diagram(coordinateSystem(extent={{-40,-40},{40,40}},
-            preserveAspectRatio=false), graphics),                    Icon(
+                    Icon(
           coordinateSystem(extent={{-40,-40},{40,40}}, preserveAspectRatio=false),
               graphics={
           Rectangle(extent={{-40,40},{40,-40}},
@@ -1200,8 +1195,7 @@ package Types "Physiological units with nominals"
   equation
         y=k;
     annotation (defaultComponentName="acceleration",
-               Diagram(coordinateSystem(extent={{-40,-40},{40,40}},
-            preserveAspectRatio=false), graphics),                    Icon(
+                    Icon(
           coordinateSystem(extent={{-40,-40},{40,40}}, preserveAspectRatio=false),
               graphics={
           Rectangle(extent={{-40,40},{40,-40}},
@@ -1245,10 +1239,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Acceleration. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Acceleration.
+    </p>
     </html>"));
     connector AccelerationOutput = output Acceleration
       "output Acceleration as connector"
@@ -1297,10 +1291,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type AmountOfSubstance. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type AmountOfSubstance.
+    </p>
     </html>"));
     connector AmountOfSubstanceOutput = output AmountOfSubstance
       "output AmountOfSubstance as connector"
@@ -1349,10 +1343,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Concentration. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Concentration.
+    </p>
     </html>"));
     connector ConcentrationOutput = output Concentration
       "output Concentration as connector"
@@ -1401,10 +1395,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type DiffusionMembranePermeability. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type DiffusionMembranePermeability.
+    </p>
     </html>"));
     connector DiffusionPermeabilityOutput = output DiffusionPermeability
       "output DiffusionPermeability as connector"
@@ -1453,10 +1447,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type ElectricCurrent. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type ElectricCurrent.
+    </p>
     </html>"));
     connector ElectricCurrentOutput = output ElectricCurrent
       "output ElectricCurrent as connector"
@@ -1505,10 +1499,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type ElectricCharge. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type ElectricCharge.
+    </p>
     </html>"));
     connector ElectricChargeOutput = output ElectricCharge
       "output ElectricCharge as connector"
@@ -1556,10 +1550,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Energy. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Energy.
+    </p>
     </html>"));
 
     connector EnergyOutput = output Energy "output Energy as connector"
@@ -1608,10 +1602,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Heat. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Heat.
+    </p>
     </html>"));
     connector HeatOutput = output Heat "output Heat as connector"
       annotation (defaultComponentName="heat",
@@ -1659,10 +1653,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type HeatFlowRate. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type HeatFlowRate.
+    </p>
     </html>"));
     connector HeatFlowRateOutput = output HeatFlowRate
       "output HeatFlowRate as connector"
@@ -1710,10 +1704,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Height. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Height.
+    </p>
     </html>"));
     connector HeightOutput = output Height "output Height as connector"
       annotation (defaultComponentName="height",
@@ -1760,10 +1754,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Mass. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Mass.
+    </p>
     </html>"));
 
     connector MassOutput = output Mass "output Mass as connector"
@@ -1813,10 +1807,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type MassFlowRate. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type MassFlowRate.
+    </p>
     </html>"));
 
     connector MassFlowRateOutput = output MassFlowRate
@@ -1867,10 +1861,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type MolarFlowRate. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type MolarFlowRate.
+    </p>
     </html>"));
     connector MolarFlowRateOutput = output MolarFlowRate
       "output MolarFlowRate as connector"
@@ -1919,10 +1913,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Concentration. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Concentration.
+    </p>
     </html>"));
     connector OsmolarityOutput = output Osmolarity
       "output Concentration as connector"
@@ -1970,10 +1964,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Pressure. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Pressure.
+    </p>
     </html>"));
 
     connector PressureOutput = output Pressure "output Pressure as connector"
@@ -2022,10 +2016,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Volume. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Volume.
+    </p>
     </html>"));
 
     connector VolumeOutput = output Volume "output Volume as connector"
@@ -2075,10 +2069,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type VolumeFlowRate. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type VolumeFlowRate.
+    </p>
     </html>"));
 
     connector VolumeFlowRateOutput = output VolumeFlowRate
@@ -2129,10 +2123,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Temperature. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Temperature.
+    </p>
     </html>"));
 
     connector TemperatureOutput = output Temperature
@@ -2181,10 +2175,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Time. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Time.
+    </p>
     </html>"));
     connector TimeOutput = output Time "output Time as connector"
       annotation (defaultComponentName="time",
@@ -2233,10 +2227,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type ThermalConductance. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type ThermalConductance.
+    </p>
     </html>"));
 
     connector ThermalConductanceOutput = output ThermalConductance
@@ -2287,10 +2281,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type ElectricPotential. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type ElectricPotential.
+    </p>
     </html>"));
 
     connector ElectricPotentialOutput = output ElectricPotential
@@ -2340,10 +2334,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Fraction. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Fraction.
+    </p>
     </html>"));
 
     connector FractionOutput = output Fraction "output Fraction as connector"
@@ -2392,10 +2386,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Frequency. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Frequency.
+    </p>
     </html>"));
 
     connector FrequencyOutput = output Frequency
@@ -2446,10 +2440,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type OsmoticMembranePermeability. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type OsmoticMembranePermeability.
+    </p>
     </html>"));
 
     connector OsmoticPermeabilityOutput = output OsmoticPermeability
@@ -2500,10 +2494,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type HydraulicConductance. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type HydraulicConductance.
+    </p>
     </html>"));
 
     connector HydraulicConductanceOutput = output HydraulicConductance
@@ -2554,10 +2548,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type HydraulicCompliance. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type HydraulicCompliance.
+    </p>
     </html>"));
 
     connector HydraulicComplianceOutput = output HydraulicCompliance
@@ -2607,10 +2601,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Volume. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Volume.
+    </p>
     </html>"));
     connector DensityOutput =output Density "output Density as connector"
       annotation (defaultComponentName="density",
@@ -2658,10 +2652,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type HydraulicInertance. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type HydraulicInertance.
+    </p>
     </html>"));
 
     connector HydraulicInertanceOutput = output HydraulicInertance
@@ -2711,10 +2705,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type GasSolubility. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type GasSolubility.
+    </p>
     </html>"));
 
     connector GasSolubilityOutput = output GasSolubility
@@ -2766,10 +2760,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Volume. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Volume.
+    </p>
     </html>"));
     connector SpecificEnergyOutput =
                              output SpecificEnergy
@@ -2820,10 +2814,10 @@ package Types "Physiological units with nominals"
               extent={{-10,85},{-10,60}},
               lineColor={0,0,127},
               textString="%name")}),
-        Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Volume. 
-    </p> 
+        Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Volume.
+    </p>
     </html>"));
     connector SpecificHeatCapacityOutput =
                              output SpecificHeatCapacity
@@ -2955,9 +2949,6 @@ constructed by the signals connected to this bus.
         extent={{-20,2},{22,-2}},
         lineColor={0,0,255},
         lineThickness=0.5)}),
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-100,
-          -100},{100,100}}),
-            graphics),
     ));
 */
     end BusConnector;
@@ -3043,8 +3034,7 @@ constructed by the signals connected to this bus.
              annotation (Dialog(group="Packages",tab="Types"));
 
           IO.Output y "Connector of Real output signal"
-            annotation (Placement(transformation(extent={{100,-10},{120,10}},
-                rotation=0)));
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 
         equation
           y = k;
@@ -3052,8 +3042,7 @@ constructed by the signals connected to this bus.
             Icon(coordinateSystem(
             preserveAspectRatio=true,
             extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics={Rectangle(
+            grid={2,2}), graphics={Rectangle(
               extent={{-100,20},{100,-20}},
               lineColor={0,0,255},
               fillPattern=FillPattern.Solid,
@@ -3063,11 +3052,6 @@ constructed by the signals connected to this bus.
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3086,8 +3070,7 @@ The Real output y is a constant signal:
                          annotation (Dialog(group="Functions to read or store",tab="Types"));
 
           IO.Output y "Connector of Real output signal"
-            annotation (Placement(transformation(extent={{100,-10},{120,10}},
-                rotation=0)));
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 
         equation
           y = k;
@@ -3095,8 +3078,7 @@ The Real output y is a constant signal:
             Icon(coordinateSystem(
             preserveAspectRatio=true,
             extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics={Rectangle(
+            grid={2,2}), graphics={Rectangle(
               extent={{-100,20},{100,-20}},
               lineColor={0,0,255},
               fillPattern=FillPattern.Solid,
@@ -3106,11 +3088,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3127,8 +3104,7 @@ The Real output y is a constant signal:
                                                          constrainedby
         Physiolibrary.Types.Utilities;
           IO.Input              y "Connector of Real input signal"
-            annotation (Placement(transformation(extent={{-100,-10},{-80,10}},
-                rotation=0), iconTransformation(extent={{-120,-10},{-100,10}})));
+            annotation (Placement(transformation(extent={{-100,-10},{-80,10}}), iconTransformation(extent={{-120,-10},{-100,10}})));
 
         equation
           when terminal() then
@@ -3152,11 +3128,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.04), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3177,8 +3148,7 @@ The Real output y is a constant signal:
 
           Modelica.Blocks.Interfaces.RealInput
                                 y "Connector of Real input signal"
-            annotation (Placement(transformation(extent={{-100,-10},{-80,10}},
-                rotation=0), iconTransformation(extent={{-120,-10},{-100,10}})));
+            annotation (Placement(transformation(extent={{-100,-10},{-80,10}}), iconTransformation(extent={{-120,-10},{-100,10}})));
 
     protected
           parameter T initialValue(fixed=false);
@@ -3209,11 +3179,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.04), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3244,10 +3209,10 @@ The Real output y is a constant signal:
                 extent={{-10,85},{-10,60}},
                 lineColor={0,0,127},
                 textString="%name")}),
-          Documentation(info="<html> 
-    <p> 
-    Connector with one input signal of type Energy. 
-    </p> 
+          Documentation(info="<html>
+    <p>
+    Connector with one input signal of type Energy.
+    </p>
     </html>"));
 
       connector Output = output Type "output connector"
@@ -3373,8 +3338,7 @@ The Real output y is a constant signal:
 
           Modelica.Blocks.Interfaces.BooleanOutput y
         "Connector of Real output signal"
-            annotation (Placement(transformation(extent={{100,-10},{120,10}},
-                rotation=0)));
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 
         equation
           y = k;
@@ -3382,8 +3346,7 @@ The Real output y is a constant signal:
             Icon(coordinateSystem(
             preserveAspectRatio=true,
             extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics={Rectangle(
+            grid={2,2}), graphics={Rectangle(
               extent={{-100,20},{100,-20}},
               lineColor={0,0,255},
               fillPattern=FillPattern.Solid,
@@ -3393,11 +3356,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3411,8 +3369,7 @@ The Real output y is a constant signal:
 
           Modelica.Blocks.Interfaces.BooleanOutput y
         "Connector of Real output signal"
-            annotation (Placement(transformation(extent={{100,-10},{120,10}},
-                rotation=0)));
+            annotation (Placement(transformation(extent={{100,-10},{120,10}})));
           replaceable package Utilities = Physiolibrary.Types.Utilities;
 
         equation
@@ -3421,8 +3378,7 @@ The Real output y is a constant signal:
             Icon(coordinateSystem(
             preserveAspectRatio=true,
             extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics={Rectangle(
+            grid={2,2}), graphics={Rectangle(
               extent={{-100,20},{100,-20}},
               lineColor={0,0,255},
               fillPattern=FillPattern.Solid,
@@ -3432,11 +3388,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3452,8 +3403,7 @@ The Real output y is a constant signal:
           Modelica.Blocks.Interfaces.BooleanInput
                                                 y
         "Connector of Real output signal"
-            annotation (Placement(transformation(extent={{-100,-10},{-80,10}},
-                rotation=0), iconTransformation(extent={{-100,-10},{-80,10}})));
+            annotation (Placement(transformation(extent={{-100,-10},{-80,10}}), iconTransformation(extent={{-100,-10},{-80,10}})));
 
         equation
           when terminal() then
@@ -3464,8 +3414,7 @@ The Real output y is a constant signal:
             Icon(coordinateSystem(
             preserveAspectRatio=true,
             extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics={Rectangle(
+            grid={2,2}), graphics={Rectangle(
               extent={{-100,20},{100,-20}},
               lineColor={0,0,255},
               fillPattern=FillPattern.Solid,
@@ -3475,11 +3424,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.1), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3496,8 +3440,7 @@ The Real output y is a constant signal:
 
           Modelica.Blocks.Interfaces.BooleanInput
                                 y "Connector of Real input signal"
-            annotation (Placement(transformation(extent={{-100,-10},{-80,10}},
-                rotation=0), iconTransformation(extent={{-120,-10},{-100,10}})));
+            annotation (Placement(transformation(extent={{-100,-10},{-80,10}}), iconTransformation(extent={{-120,-10},{-100,10}})));
 
     protected
           parameter Boolean initialValue(fixed=false);
@@ -3527,11 +3470,6 @@ The Real output y is a constant signal:
               fillColor={255,255,255},
               fillPattern=FillPattern.Solid,
               textString="%varName")}),
-            Diagram(coordinateSystem(
-            preserveAspectRatio=true,
-            extent={{-100,-100},{100,100}},
-            grid={2,2},
-            initialScale=0.04), graphics),
         Documentation(info="<html>
 <p>
 The Real output y is a constant signal:
@@ -3542,7 +3480,7 @@ The Real output y is a constant signal:
 
   package Utilities "Value input/output/test support"
     extends Modelica.Icons.BasesPackage;
-    replaceable function readReal "Read the real value of parameter from file with lines in format: 
+    replaceable function readReal "Read the real value of parameter from file with lines in format:
   <parameterName>
   <value> <unit>"
       extends Modelica.Icons.Function;
@@ -3554,7 +3492,7 @@ The Real output y is a constant signal:
     //algorithm
     end readReal;
 
-    replaceable function readBoolean "Read the boolean value of parameter from file with lines in format: 
+    replaceable function readBoolean "Read the boolean value of parameter from file with lines in format:
   <parameterName>
   <value> <unit>"
       extends Modelica.Icons.Function;
@@ -3677,8 +3615,8 @@ The Real output y is a constant signal:
                lineLen := Strings.length(line);
                nextIndex:=1;
 
-               /* 
-  //Format "<variableName>=<value><unit>" 
+               /*
+  //Format "<variableName>=<value><unit>"
   while not found and not endOfFile loop
        iline:=iline+1;
        (line, endOfFile) :=Streams.readLine(fn, iline);
@@ -3695,7 +3633,7 @@ The Real output y is a constant signal:
          str := Strings.substring(line,1,nextIndex-1);
 
          if str==name then
-                 
+
            nextIndex:=Strings.Advanced.skipWhiteSpace(line,nextIndex);
            nextIndex:=Strings.Advanced.skipWhiteSpace(line,nextIndex+1); //skip '=' and white-spaces before/after
 */
@@ -4056,8 +3994,7 @@ The Real output y is a constant signal:
         "Initialization in Steady State (initial derivations are zeros)",
       SteadyState "Steady State = Derivations are zeros during simulation")
     "Initialization or Steady state options (to determine model type before simulating)"
-      annotation (Evaluate=true, Diagram(coordinateSystem(preserveAspectRatio=
-           false, extent={{-100,-100},{100,100}}), graphics));
+      annotation (Evaluate=true);
   annotation (Documentation(revisions="<html>
 <p>Licensed by Marek Matejak under the Modelica License 2</p>
 <p>Copyright &copy; 2008-2014, Marek Matejak, Charles University in Prague.</p>

--- a/Physiolibrary/libraryinfo.mos
+++ b/Physiolibrary/libraryinfo.mos
@@ -10,4 +10,4 @@ LibraryInfoMenuCommand(
     version = "2.1.1",
     ModelicaVersion = ">=3.2",
     pos = 3753);
-  
+

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Physiolibrary  
+# Physiolibrary
 
-Physiolibrary ( http://www.physiolibrary.org ) is a free open-source Modelica library designed for modeling human physiology. 
+Physiolibrary ( http://www.physiolibrary.org ) is a free open-source Modelica library designed for modeling human physiology.
 This library contains basic physical laws governing human physiology, usable for cardiovascular circulation,
-metabolic processes, nutrient distribution, thermoregulation, gases transport, electrolyte regulation, 
+metabolic processes, nutrient distribution, thermoregulation, gases transport, electrolyte regulation,
 water distribution, hormonal regulation and pharmacological regulation.
 
 ## Library description
 
 The origin of this Modelica Physiolibrary was in the first version of our HumMod Golem Edition model implementation,
-where it was called HumMod.Library. As the successors of Guyton's Medical Physiology School write, 
+where it was called HumMod.Library. As the successors of Guyton's Medical Physiology School write,
 the original HumMod model is “The best, most complete, mathematical model of human phys-iology ever created” ( http://hummod.org ).
 
-We are also developing many types of smaller physiological models for use in medical education, 
-so it was essential to separate this library from our HumMod Modelica implementation. This separation improves 
+We are also developing many types of smaller physiological models for use in medical education,
+so it was essential to separate this library from our HumMod Modelica implementation. This separation improves
 the quality of the next HumMod release and provides a useful Modelica library to modelers in this bioscience.
 The library contains only carefully-chosen elementary physiological laws, which are the basis of more complex physiological
-processes. For example from only two type of blocks (Chemical.ChemicalReaction and Chemical.Substance) it is 
+processes. For example from only two type of blocks (Chemical.ChemicalReaction and Chemical.Substance) it is
 possible to compose the allosteric transitions or the Michaelis-Menten equation.
 
 Library contains also the icons for higher level (HumMod) subsystem implementations:
@@ -23,8 +23,8 @@ Library contains also the icons for higher level (HumMod) subsystem implementati
 ![screenshot](screenshot.png)
 
 ## Installation
-Download and unzip. 
-* install to Dymola: please call "Physiolibrary\Resources\Install\Dymola\install.bat"  
+Download and unzip.
+* install to Dymola: please call "Physiolibrary\Resources\Install\Dymola\install.bat"
 
 ## Current release
 
@@ -42,11 +42,11 @@ Download [Physiolibrary 2.1.1 (2014-05-02)](../../archive/v2.1.1.zip)
  * Upgrade to MSL 3.2.1 (still compatible with MSL 3.2)
  * New: constants HydraulicResistanceConst, HydraulicElastanceConst and HydraulicElastanceToComplianceConst and type HydraulicElastance
  * New: steady state component ElectricChargeConservationLaw
- * New: display units for hydraulic resistance/conductance/compliance/elastance, for gas solubility 
+ * New: display units for hydraulic resistance/conductance/compliance/elastance, for gas solubility
  * Rename:  HydraulicResistanceConst to HydraulicResistanceToConductanceConst
  * Fix: gas solution in liquid with corrected GasSolubility type
  * Fix: bidirectional stream flows
- * Fix: steady state example of dissolved oxygen 
+ * Fix: steady state example of dissolved oxygen
  * Fix: installation batch file for Dymola in Windows
  * Fix: references in overview (user's guide)
 
@@ -60,24 +60,24 @@ Download [Physiolibrary 2.1.1 (2014-05-02)](../../archive/v2.1.1.zip)
 *  [Version v1.2.0 (2014-01-15)](../../archive/v1.2.0.zip)
  * Package structure Physiolibrary.{domain}.[Examples|Components|Sources|Interfaces].{component}
  * New icons
- * Thermal: Relative heat energy to normal body temperature (37degC) 
- * New examples: 
-	Guyton-Coleman-Granger cardiovascular model, 
+ * Thermal: Relative heat energy to normal body temperature (37degC)
+ * New examples:
+	Guyton-Coleman-Granger cardiovascular model,
 	Coleman thermal energy transfers
 
 *  [Version v1.1.0 (2013-12-30)](../../archive/v1.1.0.zip)
  * Heat connector compatibility between Physiolibrary.Thermal package and Modelica.Thermal.HeatTransfer package (MSL 3.2)
  * Some English language corrections
  * Hydrostatic pressure patch
- * New examples 
- 
+ * New examples
+
 *  [Version v1.0.1 (2013-12-11)](../../archive/v1.0.1.zip)
  * The library uses the Modelica Standard Libary (MSL) version 3.2.
  * Contains nice physiological icons.
- * Support for physiological units: min,kcal,mmHg,ml,mEq,.. 
+ * Support for physiological units: min,kcal,mmHg,ml,mEq,..
  * Base blocks for chemical, hydraulical, osmotic, thermal or mixed domains
  * Support of euilibrated systems
- * Support for expandable inputs/outputs/tests lists 
+ * Support for expandable inputs/outputs/tests lists
 
 ## License
 


### PR DESCRIPTION
Triggered by @tbeu 's  reported
[feature request for the ttws script](https://github.com/dietmarw/trimtrailingwhitespaces/issues/12)
I ran some tests after implementing those and used also your lib
as "guinea pig". So why not putting the cleaned up result in a
pull request :-)

If you prefer to remove the cruft just before the release (as Dymola is more than willing to introduce some of it again when writing models out to disk) feel free to use the [ttws script](https://github.com/dietmarw/trimtrailingwhitespaces) yourself (but better wait for the official 0.5 release first).
