### PR TITLE
Add Area and Length types

### DIFF
--- a/Physiolibrary/Osmotic.mo
+++ b/Physiolibrary/Osmotic.mo
@@ -773,8 +773,7 @@ package Osmotic "Please use 'Chemical' library instead!"
     protected
       Types.Osmolarity o "Current osmolarity";
     public
-      Types.RealIO.TemperatureInput osmolarity(start=Osmolarity)=o if
-                                                               useOsmolarityInput
+      Types.RealIO.OsmolarityInput osmolarity(start=Osm)=o if  useOsmolarityInput
         annotation (Placement(transformation(extent={{-120,-20},{-80,20}})));
 
     initial equation

--- a/Physiolibrary/Types.mo
+++ b/Physiolibrary/Types.mo
@@ -4227,6 +4227,8 @@ This icon is designed for a <b>signal bus</b> connector.
 
   end TissueBusConnector;
 
+  type Area = Modelica.SIunits.Area (displayUnit="cm2",nominal=1e-6);
+  type Length = Modelica.SIunits.Length (displayUnit="cm",nominal=1e-3);
   type Energy = Modelica.SIunits.Energy(displayUnit="kcal", nominal=4186.8);
   type Time = Modelica.SIunits.Time(displayUnit="min", nominal=60);
   type Frequency = Modelica.SIunits.Frequency(displayUnit="1/min");


### PR DESCRIPTION
Current implementation of Osmotic.UnlimitedSolution prevents its usage due to a mismatch in start variable name. This PR fixes that.