### PR TITLE
Parse the library using moparser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "parse"
+  parse:
+    runs-on: ubuntu-latest
+    container: openmodelica/moparser:3.4
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Parse the library
+        run: moparser -v 3.4 -r Physiolibrary


### PR DESCRIPTION
When this is added to master, the Actions tab of the repository should show the jobs when a commit is pushed to master (or a pull request).
I would then fix all parser errors, push that commit... And after that enable branch protection on master so you can only merge a pull request if the action says it's OK.

You can see an example at https://github.com/sjoelund/Physiolibrary/actions where I enabled the action.
I used the moparser binary since it's a small image and should run fast on the github servers.